### PR TITLE
Created a README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+Mono.Nat
+========
+
+NAT stack for Mono and .NET applications
+
+Original website: http://projects.qnetp.net/projects/show/mono-nat
+
+
+**Note:** This project is unmaintained. You may want to try https://github.com/lontivero/Open.NAT instead.


### PR DESCRIPTION
The generic http://www.mono-project.com website you put into the GitHub description is not helpful at all. http://www.mono-project.com/Mono.Upnp is empty. Upstream was located somewhere else http://projects.qnetp.net/projects/show/mono-nat but is also dead. There is a modern fork in the makings at https://github.com/lontivero/Open.NAT you may want to direct developers instead.
