### PR TITLE
Fixed NatUtility.StopDiscovery() hanging indefinitely in Windows Forms app

### DIFF
--- a/Mono.Nat/AsyncExtensions.cs
+++ b/Mono.Nat/AsyncExtensions.cs
@@ -57,12 +57,31 @@ namespace Mono.Nat
         public static void WaitAndForget (this Task task)
         {
             try {
-                task.GetAwaiter ().GetResult ();
+                task.ConfigureAwait (false).GetAwaiter().GetResult();
             } catch (OperationCanceledException) {
                 // If we cancel the task then we don't need to log anything.
             } catch (Exception ex) {
                 Log.ErrorFormatted ("Unhandled exception: {0}{1}", Environment.NewLine, ex);
             }
+        }
+        /// <summary>
+        /// Adds cancellation functionality to a task that does not accept a CancellationToken otherwise.
+        /// https://stackoverflow.com/questions/19404199/how-to-to-make-udpclient-receiveasync-cancelable#:~:text=There's%20no%20built%2Din%20way,Delay()%20to%20implement%20timeouts).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="task"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static async Task<T> WithCancellation<T> (this Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool> ();
+            using (cancellationToken.Register (s => ((TaskCompletionSource<bool>) s).TrySetResult (true), tcs)) {
+                if (task != await Task.WhenAny (task, tcs.Task).ConfigureAwait (false)) {
+                    throw new OperationCanceledException (cancellationToken);
+                }
+            }
+
+            return task.Result;
         }
     }
 }

--- a/Mono.Nat/Pmp/Messages/Responses/ResponseMessage.cs
+++ b/Mono.Nat/Pmp/Messages/Responses/ResponseMessage.cs
@@ -48,12 +48,12 @@ namespace Mono.Nat.Pmp
             var resultCode = (ErrorCode) IPAddress.NetworkToHostOrder (BitConverter.ToInt16 (data, 2));
             uint epoch = (uint) IPAddress.NetworkToHostOrder (BitConverter.ToInt32 (data, 4));
 
-            int privatePort = IPAddress.NetworkToHostOrder (BitConverter.ToInt16 (data, 8));
-            int publicPort = IPAddress.NetworkToHostOrder (BitConverter.ToInt16 (data, 10));
+            int privatePort = (ushort)IPAddress.NetworkToHostOrder ((short) BitConverter.ToUInt16 (data, 8));
+            int publicPort = (ushort)IPAddress.NetworkToHostOrder ((short) BitConverter.ToUInt16 (data, 10));
 
             uint lifetime = (uint) IPAddress.NetworkToHostOrder (BitConverter.ToInt32 (data, 12));
 
-            if (publicPort < 0 || privatePort < 0 || resultCode != ErrorCode.Success)
+            if (resultCode != ErrorCode.Success)
                 throw new MappingException ((ErrorCode) resultCode, "Could not modify the port map");
 
             var mapping = new Mapping (protocol, privatePort, publicPort, (int) lifetime, null);

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -120,13 +120,13 @@ namespace Mono.Nat.Pmp
                 Interlocked.Exchange (ref CurrentSearchCancellation, currentSearch)?.Cancel ();
 
                 try {
-                    await SearchOnce (gatewayAddress, currentSearch.Token);
+                    await SearchOnce (gatewayAddress, currentSearch.Token).ConfigureAwait (false);
                 } catch (OperationCanceledException) {
                     token.ThrowIfCancellationRequested ();
                 }
                 if (!repeatInterval.HasValue)
                     break;
-                await Task.Delay (repeatInterval.Value, token);
+                await Task.Delay (repeatInterval.Value, token).ConfigureAwait (false);
             } while (true);
         }
 
@@ -136,8 +136,8 @@ namespace Mono.Nat.Pmp
             var delay = PmpConstants.RetryDelay;
 
             for (int i = 0; i < PmpConstants.RetryAttempts; i++) {
-                await Clients.SendAsync (buffer, gatewayAddress, token);
-                await Task.Delay (delay, token);
+                await Clients.SendAsync (buffer, gatewayAddress, token).ConfigureAwait (false);
+                await Task.Delay (delay, token).ConfigureAwait (false);
                 delay = TimeSpan.FromTicks (delay.Ticks * 2);
             }
         }

--- a/Mono.Nat/Searcher.cs
+++ b/Mono.Nat/Searcher.cs
@@ -99,7 +99,7 @@ namespace Mono.Nat
             OverallSearchCancellation = CancellationTokenSource.CreateLinkedTokenSource (Cancellation.Token);
 
             SearchTask = SearchAsync (null, SearchPeriod, OverallSearchCancellation.Token);
-            await SearchTask;
+            await SearchTask.ConfigureAwait(false);
         }
 
         public async Task SearchAsync (IPAddress gatewayAddress)


### PR DESCRIPTION
To fix `NatUtility.StopDiscovery()` hanging in [a Windows Forms app](https://github.com/bp2008/UPnPTest), I had to add several `ConfigureAwait(false)` calls.  Along the way to fixing this, I also added code to honor CancellationTokens in a few places they were being ignored.  I can't promise there are no unintended consequences to these changes, but I think it should be an overall improvement to reliability.

This pull request also includes the same fix I submitted earlier in this unrelated pull request: https://github.com/alanmcgovern/Mono.Nat/pull/29